### PR TITLE
Make user config references safe

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -100,8 +100,8 @@ class UserSettingsSkill(NeonSkill):
         from neon_utils.user_utils import apply_local_user_profile_updates
         from neon_utils.configuration_utils import NGIConfig
         user_config = NGIConfig("ngi_user_info")
-        if not all((user_config['location']['lat'],
-                    user_config['location']['lng'])):
+        if not all((user_config.get('location', {}).get('lat'),
+                    user_config.get('location', {}).get('lng'))):
             LOG.info(f'Updating default user config from ip geolocation')
             new_loc = {
                     'lat': str(updated_location['coordinate']['latitude']),


### PR DESCRIPTION
# Description
Fix issue when skill init completes before a default profile is defined

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->