### PR TITLE
Remove username example from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Neon can help you control your user preference settings via this skill.
 * Tell me my name.
 * Tell me my first name.
 * Tell me my last name.
-* Tell me my username.
 
 * Tell me my email address.
 


### PR DESCRIPTION
# Description

This is primarily so it doesn't get used as an example on the GUI home - this utterance just results in "I don't use usernames here", so it's kind of strange to suggest it as something the user can say.

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->